### PR TITLE
removed editable cells in start dlg

### DIFF
--- a/GUI/GUI.py
+++ b/GUI/GUI.py
@@ -17,7 +17,7 @@ from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLabel, QDialog, QDoubleSpinBo
     QSpinBox, QDialogButtonBox, QGridLayout, QSizePolicy, \
     QRadioButton, QStyle, QPlainTextEdit, QInputDialog, QApplication, \
     QCheckBox, QProxyStyle, QHeaderView, QComboBox, QDateEdit, QButtonGroup, QTextEdit, QTableView, \
-    QMessageBox, QMainWindow
+    QMessageBox, QMainWindow, QAbstractItemView
 
 from GUI.Models import DoubleSpinBoxDelegate, DrugTableModel
 from GUI.scope import ScopeLayoutWidget, PagedScope, ScrollingScope
@@ -1007,8 +1007,8 @@ class StartDialog(QDialog):
         # DRUG LIST TAB
         self.tableModel = DrugTableModel(self.drugList)
         self.drugTable.setModel(self.tableModel)
-        for i in range(1, self.tableModel.columnCount() - 1):
-            self.drugTable.setItemDelegateForColumn(i, DoubleSpinBoxDelegate(self))
+
+        self.drugTable.doubleClicked.connect(self.editEntry)
         self.editDrugButton.clicked.connect(self.editEntry)
         self.addDrugButton.clicked.connect(self.addEntry)
         self.delDrugButton.clicked.connect(self.removeEntry)

--- a/GUI/StartScreen.ui
+++ b/GUI/StartScreen.ui
@@ -39,6 +39,9 @@
        <property name="tabPosition">
         <enum>QTabWidget::North</enum>
        </property>
+       <property name="currentIndex">
+        <number>1</number>
+       </property>
        <widget class="QWidget" name="tabWidgetPage1">
         <attribute name="title">
          <string>Mouse</string>
@@ -222,7 +225,16 @@
               <enum>QAbstractScrollArea::AdjustToContents</enum>
              </property>
              <property name="editTriggers">
-              <set>QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="dragEnabled">
+              <bool>true</bool>
+             </property>
+             <property name="dragDropMode">
+              <enum>QAbstractItemView::DragOnly</enum>
+             </property>
+             <property name="defaultDropAction">
+              <enum>Qt::CopyAction</enum>
              </property>
              <property name="alternatingRowColors">
               <bool>true</bool>


### PR DESCRIPTION
removed the option to edit cells in place in the drug list of the start dlg. Instead, a popup is shown allowing to edit the properties.

I wanted to implement drag and drop of rows, but that seems like a giant pain, so not available for the moment

closes #8 